### PR TITLE
Fix typo, docs, logic, add missing test

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,4 +1,4 @@
-# use `jsut watch` to run tests on file save
+# use `just watch` to run tests on file save
 watch:
 	cargo watch -q -c -w . -x test
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,4 +1,4 @@
-//! This module contains functions which parsees HTML string into a custom Node struct.
+//! This module contains functions which parse HTML strings into a custom Node struct.
 //!
 //! The Node struct is used to represent the HTML elements and their children in a tree-like structure.
 //!

--- a/src/to_md.rs
+++ b/src/to_md.rs
@@ -170,7 +170,7 @@ pub fn to_md_with_config(node: Node, config: &ToMdConfig) -> String {
                     follow_child = false;
                 }
                 Li => {
-                    if !&node.children.iter().any(|child| child.tag_name == Some(P)) {
+                    if !node.children.iter().any(|child| child.tag_name == Some(P)) {
                         tail.push('\n');
                     }
                 }

--- a/tests/to_md_tests.rs
+++ b/tests/to_md_tests.rs
@@ -118,6 +118,13 @@ println!(\"{}\", z);
     }
 
     #[test]
+    fn code_block_no_leading_newline() {
+        let input = "<pre><code class=\"language-rust\">println!(\"hi\");</code></pre>".to_string();
+        let expected = "```rust\nprintln!(\"hi\");\n```\n".to_string();
+        assert_eq!(safe_from_html_to_md(input).unwrap(), expected);
+    }
+
+    #[test]
     fn line_break() {
         let input = "<p>hello<br />world</p>".to_string();
         let expected = "hello  \nworld\n".to_string();


### PR DESCRIPTION
## Summary
- fix `jsut` typo in justfile
- correct boolean expression in `to_md.rs`
- tidy grammar in parser docs
- add test for code block without leading newline

## Testing
- `cargo check` *(fails: failed to download from `https://index.crates.io/config.json`)*
- `cargo test --no-run` *(fails: failed to download from `https://index.crates.io/config.json`)*